### PR TITLE
Feat replace mock works with microCMS data

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -20,7 +20,8 @@ export default function BlogPage() {
       <header className="mb-8 space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight">Blog</h1>
         <p className="text-sm text-zinc-600 dark:text-zinc-400">
-          技術記事や学習メモの一覧ページです。microCMS 連携前の雛形として利用できます。
+          技術記事や学習メモの一覧ページです。microCMS
+          連携前の雛形として利用できます。
         </p>
       </header>
 
@@ -31,10 +32,7 @@ export default function BlogPage() {
             className="rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
           >
             <h2 className="text-base font-semibold tracking-tight">
-              <Link
-                href={`/blog/${post.slug}`}
-                className="hover:underline"
-              >
+              <Link href={`/blog/${post.slug}`} className="hover:underline">
                 {post.title}
               </Link>
             </h2>
@@ -47,4 +45,3 @@ export default function BlogPage() {
     </>
   );
 }
-

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,35 +1,55 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
+
+import { getWorksList, type Work } from "@/lib/microcms-client";
 
 export const metadata: Metadata = {
   title: "Works | null-as-0x00",
   description: "Selected works and projects.",
 };
 
-const mockWorks = [
-  {
-    slug: "sample-work",
-    title: "Sample Work",
-    summary: "ポートフォリオ用のワーク詳細ページの雛形です。",
-  },
-];
-
-export default function WorksPage() {
+function WorksEmptyState() {
   return (
-    <>
-      <header className="mb-8 space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Works</h1>
-        <p className="text-sm text-zinc-600 dark:text-zinc-400">
-          制作物・プロジェクトの一覧ページです。microCMS 連携前の雛形として利用できます。
-        </p>
-      </header>
+    <p className="rounded-xl border border-dashed border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400">
+      まだ公開中の Works はありません。新しい制作物を追加すると、ここに一覧表示されます。
+    </p>
+  );
+}
 
-      <section aria-label="Works list" className="space-y-4">
-        {mockWorks.map((work) => (
-          <article
-            key={work.slug}
-            className="rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
-          >
+type WorksListSectionProps = {
+  works: Work[];
+};
+
+function WorksListSection({ works }: WorksListSectionProps) {
+  if (!works.length) {
+    return <WorksEmptyState />;
+  }
+
+  return (
+    <section aria-label="Works list" className="space-y-4">
+      {works.map((work) => (
+        <article
+          key={work.id}
+          className="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700 sm:flex-row"
+        >
+          {work.thumbnail ? (
+            <div className="relative h-32 w-full overflow-hidden rounded-lg bg-zinc-100 sm:h-24 sm:w-40">
+              <Image
+                src={work.thumbnail.url}
+                alt={work.title}
+                fill
+                sizes="(min-width: 640px) 160px, 100vw"
+                className="object-cover"
+              />
+            </div>
+          ) : (
+            <div className="flex h-32 w-full items-center justify-center rounded-lg bg-gradient-to-br from-zinc-100 to-zinc-200 text-xs text-zinc-500 dark:from-zinc-900 dark:to-zinc-800 dark:text-zinc-400 sm:h-24 sm:w-40">
+              No thumbnail
+            </div>
+          )}
+
+          <div className="flex-1">
             <h2 className="text-base font-semibold tracking-tight">
               <Link
                 href={`/works/${work.slug}`}
@@ -38,12 +58,57 @@ export default function WorksPage() {
                 {work.title}
               </Link>
             </h2>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-              {work.summary}
-            </p>
-          </article>
-        ))}
-      </section>
+            {work.summary && (
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                {work.summary}
+              </p>
+            )}
+            {work.techStack && work.techStack.length > 0 && (
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {work.techStack.map((tech) => (
+                  <li
+                    key={tech}
+                    className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
+                  >
+                    {tech}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+export default async function WorksPage() {
+  let works: Work[] = [];
+  let isError = false;
+
+  try {
+    const { contents } = await getWorksList();
+    works = contents;
+  } catch (error) {
+    console.error("[WorksPage] Failed to fetch works list from microCMS:", error);
+    isError = true;
+  }
+
+  return (
+    <>
+      <header className="mb-8 space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Works</h1>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          制作物・プロジェクトの一覧ページです。microCMS と連携した実データを表示します。
+        </p>
+        {isError && (
+          <p className="text-xs text-red-600 dark:text-red-400">
+            Works の取得中にエラーが発生しました。時間をおいて再度お試しください。
+          </p>
+        )}
+      </header>
+
+      <WorksListSection works={works} />
     </>
   );
 }


### PR DESCRIPTION
## 概要
`/works` ページの一覧を、モック配列から microCMS の `works` コンテンツに置き換えました。  
App Router のサーバーコンポーネントから `getWorksList` を呼び出すことで、SSR/SSG ベースでのデータ取得を行っています。

## 変更内容
- `src/app/works/page.tsx`
  - コンポーネントを `async` サーバーコンポーネント化
  - `getWorksList` を利用して microCMS から Works 一覧を取得
  - `Work` 型に沿ってタイトル・summary・サムネイル（あれば）をカード UI で表示
  - Works が 0件の場合用のメッセージを追加
  - 取得失敗時の簡易エラーメッセージを表示

## 備考
- 今回は一覧のみ SSR/SSG 対応。詳細ページや Blog 側の microCMS 連携は別 Issue で対応します。