### PR TITLE
Feat add microCMS-powered work detail page

### DIFF
--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -1,44 +1,226 @@
+import Image from "next/image";
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
-type WorkDetailPageProps = {
-  params: Promise<{
+import {
+  getWorkBySlug,
+  getWorksList,
+  type Work,
+} from "@/lib/microcms-client";
+
+type WorkDetailPageParams = {
+  params: {
     slug: string;
-  }>;
+  };
 };
 
+export async function generateStaticParams() {
+  const { contents } = await getWorksList({
+    fields: "id,slug",
+    limit: 100,
+  });
+
+  return contents.map((work) => ({
+    slug: work.slug,
+  }));
+}
+
 export async function generateMetadata(
-  { params }: WorkDetailPageProps,
+  { params }: WorkDetailPageParams,
 ): Promise<Metadata> {
-  const { slug } = await params;
+  const work = await getWorkBySlug(params.slug);
+
+  if (!work) {
+    return {
+      title: "Work not found | null-as-0x00",
+    };
+  }
 
   return {
-    title: `${slug} | Works | null-as-0x00`,
+    title: `${work.title} | Works | null-as-0x00`,
+    description: work.summary || "Work detail page.",
   };
 }
 
-export default async function WorkDetailPage({ params }: WorkDetailPageProps) {
-  const { slug } = await params;
+type WorkHeaderProps = {
+  work: Work;
+};
 
+function WorkHeader({ work }: WorkHeaderProps) {
   return (
-    <article className="space-y-6">
-      <header className="space-y-2">
+    <header className="space-y-4">
+      <div className="space-y-2">
         <p className="text-xs uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
           Work Detail
         </p>
         <h1 className="text-2xl font-semibold tracking-tight">
-          {slug}
+          {work.title}
         </h1>
-        <p className="text-sm text-zinc-600 dark:text-zinc-400">
-          ここに microCMS などから取得した制作物の詳細情報を表示します。
-        </p>
-      </header>
+        {work.summary && (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            {work.summary}
+          </p>
+        )}
+      </div>
 
-      <section className="prose prose-zinc max-w-none dark:prose-invert">
-        <p>
-          このページは Dynamic Route (`/works/[slug]`) 用の雛形です。今後、ビジュアル、
-          技術スタック、役割、リンクなどのセクションを追加して拡張できます。
-        </p>
-      </section>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+        {work.publishedAt && (
+          <span>
+            Published{" "}
+            <time dateTime={work.publishedAt}>
+              {new Date(work.publishedAt).toLocaleDateString("ja-JP")}
+            </time>
+          </span>
+        )}
+        {work.updatedAt && (
+          <span>
+            Updated{" "}
+            <time dateTime={work.updatedAt}>
+              {new Date(work.updatedAt).toLocaleDateString("ja-JP")}
+            </time>
+          </span>
+        )}
+      </div>
+    </header>
+  );
+}
+
+type WorkTechStackProps = {
+  techStack?: string[];
+};
+
+function WorkTechStack({ techStack }: WorkTechStackProps) {
+  if (!techStack || techStack.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Used technologies" className="space-y-2">
+      <h2 className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        Tech stack
+      </h2>
+      <ul className="flex flex-wrap gap-1.5">
+        {techStack.map((tech) => (
+          <li
+            key={tech}
+            className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+          >
+            {tech}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+type WorkLinksProps = {
+  work: Work;
+};
+
+function WorkLinks({ work }: WorkLinksProps) {
+  if (!work.siteUrl && !work.repoUrl) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Project links" className="space-y-2">
+      <h2 className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        Links
+      </h2>
+      <div className="flex flex-wrap gap-2 text-sm">
+        {work.siteUrl && (
+          <a
+            href={work.siteUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-medium text-zinc-800 transition hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:hover:border-zinc-700 dark:hover:bg-zinc-900"
+          >
+            Visit site
+          </a>
+        )}
+        {work.repoUrl && (
+          <a
+            href={work.repoUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-medium text-zinc-800 transition hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:hover:border-zinc-700 dark:hover:bg-zinc-900"
+          >
+            View repository
+          </a>
+        )}
+      </div>
+    </section>
+  );
+}
+
+type WorkBodyProps = {
+  body?: string;
+};
+
+function WorkBody({ body }: WorkBodyProps) {
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Work description" className="space-y-2">
+      <h2 className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        Overview
+      </h2>
+      <div className="prose prose-zinc max-w-none text-sm dark:prose-invert">
+        <p>{body}</p>
+      </div>
+    </section>
+  );
+}
+
+type WorkThumbnailProps = {
+  work: Work;
+};
+
+function WorkThumbnail({ work }: WorkThumbnailProps) {
+  if (!work.thumbnail) {
+    return null;
+  }
+
+  return (
+    <div className="relative h-56 w-full overflow-hidden rounded-xl bg-zinc-100 sm:h-64">
+      <Image
+        src={work.thumbnail.url}
+        alt={work.title}
+        fill
+        sizes="(min-width: 768px) 768px, 100vw"
+        className="object-cover"
+      />
+    </div>
+  );
+}
+
+export default async function WorkDetailPage(
+  { params }: WorkDetailPageParams,
+) {
+  const work = await getWorkBySlug(params.slug);
+
+  if (!work) {
+    notFound();
+  }
+
+  return (
+    <article className="space-y-8">
+      <WorkHeader work={work} />
+
+      <div className="space-y-8">
+        <WorkThumbnail work={work} />
+
+        <div className="grid gap-8 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <WorkBody body={work.body} />
+
+          <div className="space-y-6">
+            <WorkTechStack techStack={work.techStack} />
+            <WorkLinks work={work} />
+          </div>
+        </div>
+      </div>
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- `/works/[slug]` を microCMS の `works` モデルと slug で表示するよう変更
- `generateStaticParams` で microCMS 上の全 Works を静的生成
- body / techStack / URL をセクション分けしたレイアウトに整備
- 存在しない slug に対して `notFound()` を返すハンドリングを追加

## Changes
- Implement `generateStaticParams` in `src/app/works/[slug]/page.tsx`
- Use `getWorkBySlug` to fetch a single work by slug
- Add structured layout for title, tech stack, body, external links
