### PR TITLE
Feat replace mock blog list with microCMS data

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,47 +1,113 @@
+import Image from "next/image";
 import type { Metadata } from "next";
 import Link from "next/link";
+
+import { getBlogList, type BlogPost } from "@/lib/microcms-client";
 
 export const metadata: Metadata = {
   title: "Blog | null-as-0x00",
   description: "Articles and engineering notes.",
 };
 
-const mockPosts = [
-  {
-    slug: "sample-post",
-    title: "Sample Blog Post",
-    summary: "ポートフォリオ用のブログ記事ページの雛形です。",
-  },
-];
+function BlogEmptyState() {
+  return (
+    <p className="rounded-xl border border-dashed border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400">
+      まだ公開中の Blog 記事はありません。記事を追加すると、ここに一覧表示されます。
+    </p>
+  );
+}
 
-export default function BlogPage() {
+type BlogListSectionProps = {
+  posts: BlogPost[];
+};
+
+function BlogListSection({ posts }: BlogListSectionProps) {
+  if (!posts.length) {
+    return <BlogEmptyState />;
+  }
+
+  return (
+    <section aria-label="Blog posts list" className="space-y-4">
+      {posts.map((post) => (
+        <article
+          key={post.id}
+          className="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700 sm:flex-row"
+        >
+          {post.thumbnail ? (
+            <div className="relative h-24 w-full overflow-hidden rounded-lg bg-zinc-100 sm:h-24 sm:w-40">
+              <Image
+                src={post.thumbnail.url}
+                alt={post.title}
+                fill
+                sizes="(min-width: 640px) 160px, 100vw"
+                className="object-cover"
+              />
+            </div>
+          ) : (
+            <div className="flex h-24 w-full items-center justify-center rounded-lg bg-gradient-to-br from-zinc-100 to-zinc-200 text-xs text-zinc-500 dark:from-zinc-900 dark:to-zinc-800 dark:text-zinc-400 sm:w-40">
+              No thumbnail
+            </div>
+          )}
+
+          <div className="flex-1">
+            <h2 className="text-base font-semibold tracking-tight">
+              <Link
+                href={`/blog/${post.slug}`}
+                className="hover:underline"
+              >
+                {post.title}
+              </Link>
+            </h2>
+            {post.excerpt && (
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                {post.excerpt}
+              </p>
+            )}
+            <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+              {post.category && <span>{post.category}</span>}
+              {post.publishedAt && (
+                <span>
+                  Published{" "}
+                  <time dateTime={post.publishedAt}>
+                    {new Date(post.publishedAt).toLocaleDateString("ja-JP")}
+                  </time>
+                </span>
+              )}
+            </div>
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+export default async function BlogPage() {
+  let posts: BlogPost[] = [];
+  let isError = false;
+
+  try {
+    const { contents } = await getBlogList();
+    posts = contents;
+  } catch (error) {
+    console.error("[BlogPage] Failed to fetch blog posts from microCMS:", error);
+    isError = true;
+  }
+
   return (
     <>
       <header className="mb-8 space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight">Blog</h1>
         <p className="text-sm text-zinc-600 dark:text-zinc-400">
-          技術記事や学習メモの一覧ページです。microCMS
-          連携前の雛形として利用できます。
+          技術記事や学習メモの一覧ページです。microCMS と連携した実データを表示します。
         </p>
+        {isError && (
+          <p className="text-xs text-red-600 dark:text-red-400">
+            Blog 記事の取得中にエラーが発生しました。時間をおいて再度お試しください。
+          </p>
+        )}
       </header>
 
-      <section aria-label="Blog posts list" className="space-y-4">
-        {mockPosts.map((post) => (
-          <article
-            key={post.slug}
-            className="rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
-          >
-            <h2 className="text-base font-semibold tracking-tight">
-              <Link href={`/blog/${post.slug}`} className="hover:underline">
-                {post.title}
-              </Link>
-            </h2>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-              {post.summary}
-            </p>
-          </article>
-        ))}
-      </section>
+      <BlogListSection posts={posts} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- `/blog` ページの一覧を microCMS の `blog` モデルから取得するように変更
- `BlogPost` 型を用いてタイトル・excerpt・thumbnail を SSR/SSG で表示
- 0件時メッセージと取得失敗時の簡易エラーメッセージを追加
- 各記事の詳細ページ `/blog/[slug]` へのリンクを slug ベースで接続

## Changes
- Update `src/app/blog/page.tsx` to use `getBlogList`
- Remove mock data and render cards from `BlogPost` contents
- Add empty state UI when there are no blog posts
