### PR TITLE
Fix resolve metadata params promise

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,9 +9,9 @@ import {
 } from "@/lib/microcms-client";
 
 type BlogDetailPageParams = {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 };
 
 export async function generateStaticParams() {
@@ -28,7 +28,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: BlogDetailPageParams): Promise<Metadata> {
-  const post = await getBlogBySlug(params.slug);
+  const { slug } = await params;
+  const post = await getBlogBySlug(slug);
 
   if (!post) {
     return {
@@ -138,7 +139,8 @@ function BlogBody({ body }: BlogBodyProps) {
 }
 
 export default async function BlogDetailPage({ params }: BlogDetailPageParams) {
-  const post = await getBlogBySlug(params.slug);
+  const { slug } = await params;
+  const post = await getBlogBySlug(slug);
 
   if (!post) {
     notFound();

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -5,9 +5,9 @@ import { notFound } from "next/navigation";
 import { getWorkBySlug, getWorksList, type Work } from "@/lib/microcms-client";
 
 type WorkDetailPageParams = {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 };
 
 export async function generateStaticParams() {
@@ -24,7 +24,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: WorkDetailPageParams): Promise<Metadata> {
-  const work = await getWorkBySlug(params.slug);
+  const { slug } = await params;
+  const work = await getWorkBySlug(slug);
 
   if (!work) {
     return {
@@ -203,7 +204,8 @@ function WorkThumbnail({ work }: WorkThumbnailProps) {
 }
 
 export default async function WorkDetailPage({ params }: WorkDetailPageParams) {
-  const work = await getWorkBySlug(params.slug);
+  const { slug } = await params;
+  const work = await getWorkBySlug(slug);
 
   if (!work) {
     notFound();


### PR DESCRIPTION
# fix: update dynamic route params to be awaited (Next.js 15 compatibility)

## 変更内容
Next.js 15 の仕様変更（Async Request APIs）に合わせて、動的ルートの `params` の扱いを修正しました。

- **型定義の更新**: `params` を `Promise` でラップするよう変更。
- **実装の修正**: `generateMetadata` および `Page` コンポーネント内で `params` を `await` するように修正。
