### PR TITLE
fix: render HTML content from microCMS

### DIFF
--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -183,7 +183,7 @@ function WorkBody({ body }: WorkBodyProps) {
       </h2>
       {/* prose-invert でダークモード時のタイポグラフィを自動調整 */}
       <div className="prose prose-zinc max-w-none text-sm dark:prose-invert text-color-muted">
-        <p>{body}</p>
+        <div dangerouslySetInnerHTML={{ __html: body }} />
       </div>
     </section>
   );


### PR DESCRIPTION
## 修正内容
- microCMSから取得したHTML文字列をそのまま表示していた箇所を、`dangerouslySetInnerHTML` を使用するように変更しました。
- ユーザーに `<p>` などの生タグが見えてしまう問題を修正しました。

## 実装の詳細
ワーク詳細ページにおいて、以下のようにHTMLをDOMに安全に挿入するよう変更しました：
```tsx
<div dangerouslySetInnerHTML={{ __html: body }} />